### PR TITLE
zlib inflation should auto-determine its window size.

### DIFF
--- a/lib/spdy/utils.js
+++ b/lib/spdy/utils.js
@@ -46,7 +46,7 @@ utils.createInflate = function createInflate(version) {
   var inflate = zlib.createInflate({
     dictionary: spdy.protocol.dictionary[version],
     flush: zlib.Z_SYNC_FLUSH,
-    windowBits: 15
+    windowBits: 0
   });
 
   // Define lock information early


### PR DESCRIPTION
Setting windowBits to 15 allocates 32k of memory for the inflation buffer (the largest legal zlib window). The sender may be using a smaller window (and with SPDY, likely is), so this can be a significant waste of memory if there are many connections.

From [`inflateInit2()`](http://www.zlib.net/manual.html):

> windowBits can also be zero to request that inflate use the window size in the zlib header of the compressed stream.
