### PR TITLE
Travis test against node 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
+  - "0.12"
 branches:
   only:
     - master


### PR DESCRIPTION
Since node 0.12 is now stable, it makes sense to run Travis agains Node 12