### PR TITLE
If :status is already set, don't override it.

### DIFF
--- a/lib/spdy/protocol/framer.js
+++ b/lib/spdy/protocol/framer.js
@@ -196,7 +196,8 @@ Framer.prototype.replyFrame = function replyFrame(id,
       headers.status = code + ' ' + reason;
       headers.version = 'HTTP/1.1';
     } else {
-      headers[':status'] = code + ' ' + reason;
+      if (!(':status' in headers))
+        headers[':status'] = code + ' ' + reason;
       headers[':version'] = 'HTTP/1.1';
     }
   });
@@ -236,8 +237,9 @@ Framer.prototype.streamFrame = function streamFrame(id,
       if (meta.method)
         headers.method = meta.method;
     } else {
-      if (meta.status)
-        headers[':status'] = meta.status;
+      if (!(':status' in headers))
+        if (meta.status)
+          headers[':status'] = meta.status;
       headers[':version'] = meta.version || 'HTTP/1.1';
       headers[':path'] = meta.path || meta.url;
       headers[':scheme'] = meta.scheme || 'https';


### PR DESCRIPTION
Some code like https://www.igvita.com/2013/06/12/innovating-with-http-2.0-server-push/ sets `headers[':status']` to give a custom status on server pushes, and unconditionally overriding `headers[':status']` means you can't set it.

I'm not sure how to run the tests, so I haven't run them.

Fixes https://github.com/indutny/node-spdy/issues/206