### PR TITLE
Fix exports to export the Agent

### DIFF
--- a/lib/spdy.js
+++ b/lib/spdy.js
@@ -9,7 +9,7 @@ spdy.response = require('./spdy/response');
 
 // Export client
 spdy.agent = require('./spdy/agent');
-spdy.Agent = spdy.agent;
+spdy.Agent = spdy.agent.Agent;
 spdy.createAgent = spdy.agent.create;
 
 // Export server


### PR DESCRIPTION
The `spdy.Agent` export doesn't export the Agent prototype correctly. This PR fixes the issue.