### PR TITLE
Docs: PUSH_PROMISE no longer has 'acknowledge'.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,6 @@ spdy.createServer(options, function(req, res) {
       'content-type': 'application/javascript'
     }
   });
-  stream.on('acknowledge', function() {
-  });
   stream.on('error', function() {
   });
   stream.end('alert("hello from push stream!");');


### PR DESCRIPTION
Push Promise used to emit a 'acknowledge' event. This is no longer present in v2.

#125 was for docs on this event.

I'm not sure yet what the replacement is for knowing when a Push Promise has succeeded? Needed for jshttp/spdy-push#3.