### PR TITLE
Accept 'h2' as a connection protocol.

### DIFF
--- a/lib/spdy/server.js
+++ b/lib/spdy/server.js
@@ -108,7 +108,7 @@ proto._handleConnection = function _handleConnection(socket, protocol) {
   }, state.options.connection || {}));
 
   // Set version when we are certain
-  if (protocol === 'http2')
+  if (protocol === 'http2' || protocol === 'h2')
     connection.start(4);
   else if (protocol === 'spdy/3.1')
     connection.start(3.1);


### PR DESCRIPTION
Not sure if this is a problem or not.

Stepping through unit tests in jshttp/spdy-push, I noticed the incoming connection to the server was protocol 'h2' but server was only starting the connection for 'http2' and spdy strings.