### PR TITLE
Removed CA option from README and added some comments on key/cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ var spdy = require('spdy'),
     fs = require('fs');
 
 var options = {
+  // Private key
   key: fs.readFileSync(__dirname + '/keys/spdy-key.pem'),
-  cert: fs.readFileSync(__dirname + '/keys/spdy-cert.pem'),
-  ca: fs.readFileSync(__dirname + '/keys/spdy-ca.pem'),
+
+  // Fullchain file or cert file (prefer the former)
+  cert: fs.readFileSync(__dirname + '/keys/spdy-fullchain.pem'),
 
   // **optional** SPDY-specific options
   spdy: {


### PR DESCRIPTION
The outer options are passed directly into node https API, those are not options of `node-spdy`. Because of this, the README can be somewhat confusing for people who don't understand how certificates works.

Lot of new people use Let's Encrypt now, which provides chain.pem (CA file). This can be confusing and people would add that file inside `ca` option, which is wrong.

> `ca`: A string, Buffer or array of strings or Buffers of trusted certificates in PEM format. If this is omitted several well known "root" CAs will be used, like VeriSign. These are used to authorize connections.

Since is not an option of `node-spdy` and it's just another option of many from node https API, removing it from this readme would be a good idea, since most times this option is not needed and will be missused.

Also, added some comments that can help newcomers. It's better idea to use the `fullchain.pem` file (Let's Encrypt provide it) than just `cert.pem`.