### PR TITLE
Fix uncaught exception on prematurely terminated connections

### DIFF
--- a/lib/spdy/response.js
+++ b/lib/spdy/response.js
@@ -80,12 +80,12 @@ exports.push = function push(path, headers, callback) {
     path: path,
     method: headers.method ? headers.method.toString() : 'GET',
     status: headers.status ? parseInt(headers.status, 10) : 200,
-    host: this.socket.parser.incoming.headers.host,
+    host: this._req.headers.host,
     headers: headers.request,
     response: headers.response
   };
 
-  var stream = this.socket._handle._spdyState.stream;
+  var stream = this.spdyStream;
   return stream.pushPromise(frame, callback);
 };
 

--- a/lib/spdy/server.js
+++ b/lib/spdy/server.js
@@ -237,6 +237,8 @@ proto.emit = function emit(event, req, res) {
   res.writeContinue = spdy.response.writeContinue;
   res.spdyStream = handle.getStream();
 
+  res._req = req;
+
   handle.assignRequest(req);
   handle.assignResponse(res);
 

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -313,6 +313,31 @@ describe('SPDY Server', function() {
       });
     });
 
+    it('should not crash on .push() after socket close', function(done) {
+      var stream = client.request({
+        method: 'POST',
+        path: '/post'
+      }, function(err) {
+        assert(!err);
+
+        setTimeout(function() {
+          client.socket.destroy();
+        }, 50);
+        stream.on('error', function() {});
+        stream.end();
+      });
+
+      server.on('request', function(req, res) {
+        req.connection.on('close', function() {
+          assert.doesNotThrow(function() {
+            assert.equal(res.push('/push', {}), undefined);
+            res.end('response');
+          });
+          done();
+        });
+      });
+    });
+
     it('should end response after writing everything down', function(done) {
       var stream = client.request({
         method: 'GET',


### PR DESCRIPTION
When a SPDY connection is terminated prematurely, it is possible for user-code
to still hold references to the request and response objects and perform
operations on them, including creating a new push stream. This condition can
trigger an uncaught exception when the underlying connection has been closed.

This commit fixes an issue in the Response class by eliminating the need to
read the name of the connected host using the parser attached to the socket.
Instead, it uses a reference to its corresponding request object (now setup
in server.js when a "request" event is fired) to read the HTTP Host header.