### PR TITLE
Fallback to using specified protocol (if available) in secure mode

### DIFF
--- a/lib/spdy/agent.js
+++ b/lib/spdy/agent.js
@@ -110,10 +110,13 @@ proto._connect = function _connect(options, callback) {
     socket.removeListener('error', onError);
 
     var protocol;
-    if (state.secure)
-      protocol = socket.npnProtocol || socket.alpnProtocol;
-    else
+    if (state.secure) {
+      protocol = socket.npnProtocol ||
+                 socket.alpnProtocol ||
+                 state.options.protocol;
+    } else {
       protocol = state.options.protocol;
+    }
 
     // HTTP server - kill socket and switch to the fallback mode
     if (!protocol || protocol === 'http/1.1' || protocol === 'http/1.0') {


### PR DESCRIPTION
On older versions of node with no ALPN support, `socket.npnProtocol` is
returned as `undefined`, resulting in the activation of fallback mode.
This commit allows for falling back to a user-defined protocol in case
NPN/ALPN extensions aren't available.